### PR TITLE
Adds optional flag: `state_logo_white` to render the logo in white only

### DIFF
--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -51,3 +51,6 @@ properties:
 
   state_logo:
     type: string
+
+  state_logo_white:
+    type: boolean

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -10,5 +10,6 @@
     "kasp_enabled": false,
     "kasp_string": "KASP",
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",
-    "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo.svg"
+    "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo.svg",
+    "state_logo_white": true
 }


### PR DESCRIPTION
> ℹ️ Related front-end PR: 
> - https://github.com/coronasafe/care_fe/pull/4627

If `state_logo` is defined and setting the optional config `state_logo_white` to `true` causes the provided logo to be rendered in white as shown below. Otherwise just renders the original image.

![image](https://user-images.githubusercontent.com/25143503/213237834-7d7a72c2-d1d6-42ac-b506-a17056678ff0.png)
