### PR TITLE
Adds additional white labels (url and logo of DPG and CSN, sample format files of asset and external results)

### DIFF
--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -7,7 +7,6 @@ required:
   - github_url
   - coronasafe_url
   - dpg_url
-  - app_loader_image
   - static_header_logo
   - static_light_logo
   - static_black_logo
@@ -33,9 +32,6 @@ properties:
     type: string
 
   dpg_url:
-    type: string
-
-  app_loader_image:
     type: string
 
   static_header_logo:

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -6,6 +6,7 @@ required:
   - dashboard_url
   - github_url
   - coronasafe_url
+  - dpg_url
   - app_loader_image
   - static_header_logo
   - static_light_logo
@@ -29,6 +30,9 @@ properties:
     type: string
 
   coronasafe_url:
+    type: string
+
+  dpg_url:
     type: string
 
   app_loader_image:

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -31,6 +31,9 @@ properties:
   static_black_logo:
     type: string
 
+  static_dpg_white_logo:
+    type: string
+
   gmaps_api_key:
     type: string
 

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -5,6 +5,8 @@ type: object
 required:
   - dashboard_url
   - github_url
+  - coronasafe_url
+  - app_loader_image
   - static_header_logo
   - static_light_logo
   - static_black_logo
@@ -16,7 +18,7 @@ required:
   - kasp_enabled
   - kasp_string
   - kasp_full_string
-  - asset_import_sample_format
+  - sample_format_asset_import
 
 properties:
   dashboard_url:
@@ -26,6 +28,9 @@ properties:
     type: string
 
   coronasafe_url:
+    type: string
+
+  app_loader_image:
     type: string
 
   static_header_logo:
@@ -67,5 +72,8 @@ properties:
   state_logo_white:
     type: boolean
 
-  asset_import_sample_format:
+  sample_format_asset_import:
+    type: string
+
+  sample_format_external_result:
     type: string

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -19,6 +19,7 @@ required:
   - kasp_string
   - kasp_full_string
   - sample_format_asset_import
+  - sample_format_external_result_import
 
 properties:
   dashboard_url:
@@ -75,5 +76,5 @@ properties:
   sample_format_asset_import:
     type: string
 
-  sample_format_external_result:
+  sample_format_external_result_import:
     type: string

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -24,6 +24,9 @@ properties:
   github_url:
     type: string
 
+  coronasafe_url:
+    type: string
+
   static_header_logo:
     type: string
 

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -8,6 +8,8 @@ required:
   - static_header_logo
   - static_light_logo
   - static_black_logo
+  - static_dpg_white_logo
+  - static_coronasafe_logo
   - gmaps_api_key
   - gov_data_api_key
   - recaptcha_site_key
@@ -32,6 +34,9 @@ properties:
     type: string
 
   static_dpg_white_logo:
+    type: string
+
+  static_coronasafe_logo:
     type: string
 
   gmaps_api_key:

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -16,6 +16,7 @@ required:
   - kasp_enabled
   - kasp_string
   - kasp_full_string
+  - asset_import_sample_format
 
 properties:
   dashboard_url:
@@ -65,3 +66,6 @@ properties:
 
   state_logo_white:
     type: boolean
+
+  asset_import_sample_format:
+    type: string

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -16,5 +16,5 @@
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",
     "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
     "sample_format_asset_import": "https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=11JaEhNHdyCHth4YQs_44YaRlP77Rrqe81VSEfg1glko&exportFormat=xlsx",
-    "sample_format_external_result": "https://docs.google.com/spreadsheets/d/17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE/export?format=csv&id=17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE"
+    "sample_format_external_result_import": "https://docs.google.com/spreadsheets/d/17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE/export?format=csv&id=17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE"
 }

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -13,5 +13,6 @@
     "kasp_enabled": false,
     "kasp_string": "KASP",
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",
-    "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg"
+    "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
+    "asset_import_sample_format": "https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=11JaEhNHdyCHth4YQs_44YaRlP77Rrqe81VSEfg1glko&exportFormat=xlsx"
 }

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -4,12 +4,12 @@
     "static_header_logo": "https://cdn.coronasafe.network/header_logo.png",
     "static_light_logo": "https://cdn.coronasafe.network/light-logo.svg",
     "static_black_logo": "https://cdn.coronasafe.network/black-logo.svg",
+    "static_dpg_white_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
     "gmaps_api_key": "AIzaSyDsBAc3y7deI5ZO3NtK5GuzKwtUzQNJNUk",
     "gov_data_api_key": "579b464db66ec23bdd000001cdd3946e44ce4aad7209ff7b23ac571b",
     "recaptcha_site_key": "6LdvxuQUAAAAADDWVflgBqyHGfq-xmvNJaToM0pN",
     "kasp_enabled": false,
     "kasp_string": "KASP",
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",
-    "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo.svg",
-    "state_logo_white": true
+    "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg"
 }

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -2,6 +2,7 @@
     "dashboard_url": "https://dashboard.coronasafe.in",
     "github_url": "https://github.com/coronasafe",
     "coronasafe_url": "https://coronasafe.network?ref=care",
+    "app_loader_image": "https://cdn.coronasafe.network/break-chain.webp",
     "static_header_logo": "https://cdn.coronasafe.network/header_logo.png",
     "static_light_logo": "https://cdn.coronasafe.network/light-logo.svg",
     "static_black_logo": "https://cdn.coronasafe.network/black-logo.svg",
@@ -14,5 +15,6 @@
     "kasp_string": "KASP",
     "kasp_full_string": "Karunya Arogya Suraksha Padhathi",
     "state_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
-    "asset_import_sample_format": "https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=11JaEhNHdyCHth4YQs_44YaRlP77Rrqe81VSEfg1glko&exportFormat=xlsx"
+    "sample_format_asset_import": "https://spreadsheets.google.com/feeds/download/spreadsheets/Export?key=11JaEhNHdyCHth4YQs_44YaRlP77Rrqe81VSEfg1glko&exportFormat=xlsx",
+    "sample_format_external_result": "https://docs.google.com/spreadsheets/d/17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE/export?format=csv&id=17VfgryA6OYSYgtQZeXU9mp7kNvLySeEawvnLBO_1nuE"
 }

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -1,6 +1,7 @@
 {
     "dashboard_url": "https://dashboard.coronasafe.in",
     "github_url": "https://github.com/coronasafe",
+    "coronasafe_url": "https://coronasafe.network?ref=care",
     "static_header_logo": "https://cdn.coronasafe.network/header_logo.png",
     "static_light_logo": "https://cdn.coronasafe.network/light-logo.svg",
     "static_black_logo": "https://cdn.coronasafe.network/black-logo.svg",

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -3,7 +3,6 @@
     "github_url": "https://github.com/coronasafe",
     "coronasafe_url": "https://coronasafe.network?ref=care",
     "dpg_url": "https://digitalpublicgoods.net/registry/coronasafe-care.html",
-    "app_loader_image": "https://cdn.coronasafe.network/break-chain.webp",
     "static_header_logo": "https://cdn.coronasafe.network/header_logo.png",
     "static_light_logo": "https://cdn.coronasafe.network/light-logo.svg",
     "static_black_logo": "https://cdn.coronasafe.network/black-logo.svg",

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -5,6 +5,7 @@
     "static_light_logo": "https://cdn.coronasafe.network/light-logo.svg",
     "static_black_logo": "https://cdn.coronasafe.network/black-logo.svg",
     "static_dpg_white_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
+    "static_coronasafe_logo": "https://3451063158-files.gitbook.io/~/files/v0/b/gitbook-legacy-files/o/assets%2F-M233b0_JITp4nk0uAFp%2F-M2Dx6gKxOSU45cjfgNX%2F-M2DxFOkMmkPNn0I6U9P%2FCoronasafe-logo.png?alt=media&token=178cc96d-76d9-4e27-9efb-88f3186368e8",
     "gmaps_api_key": "AIzaSyDsBAc3y7deI5ZO3NtK5GuzKwtUzQNJNUk",
     "gov_data_api_key": "579b464db66ec23bdd000001cdd3946e44ce4aad7209ff7b23ac571b",
     "recaptcha_site_key": "6LdvxuQUAAAAADDWVflgBqyHGfq-xmvNJaToM0pN",

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -2,6 +2,7 @@
     "dashboard_url": "https://dashboard.coronasafe.in",
     "github_url": "https://github.com/coronasafe",
     "coronasafe_url": "https://coronasafe.network?ref=care",
+    "dpg_url": "https://digitalpublicgoods.net/registry/coronasafe-care.html",
     "app_loader_image": "https://cdn.coronasafe.network/break-chain.webp",
     "static_header_logo": "https://cdn.coronasafe.network/header_logo.png",
     "static_light_logo": "https://cdn.coronasafe.network/light-logo.svg",


### PR DESCRIPTION
### Newly added white labels
- `static_dpg_white_logo`: image resource URL of [white logo of digital public goods](https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg).
- `static_coronasafe_logo`: image resource URL of coronasafe logo
- `coronasafe_url`: URL to coronasafe.network (https://coronasafe.network?ref=care)
- `dpg_url`: URL to Coronasafe Care DPG Registry (https://digitalpublicgoods.net/registry/coronasafe-care.html)
- `sample_format_asset_import`: sample format file for asset import
- `sample_format_external_result_import`: sample format file of external result import

### Other updates

- `state_logo` to use the official white logo of DPG instead of inverting the default logo to white via `state_logo_white` flag.