### PR TITLE
Removed references of static_coronasafe_logo

### DIFF
--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -15,7 +15,6 @@ required:
   - static_ohc_light_logo
   - static ohc_green_logo
   - static_dpg_white_logo
-  - static_coronasafe_logo
   - gmaps_api_key
   - gov_data_api_key
   - recaptcha_site_key
@@ -62,9 +61,6 @@ properties:
     type: string
 
   static_dpg_white_logo:
-    type: string
-
-  static_coronasafe_logo:
     type: string
 
   gmaps_api_key:

--- a/config_schema.yaml
+++ b/config_schema.yaml
@@ -12,6 +12,8 @@ required:
   - static_header_logo
   - static_light_logo
   - static_black_logo
+  - static_ohc_light_logo
+  - static ohc_green_logo
   - static_dpg_white_logo
   - static_coronasafe_logo
   - gmaps_api_key
@@ -51,6 +53,12 @@ properties:
     type: string
 
   static_black_logo:
+    type: string
+
+  static_ohc_light_logo:
+    type: string
+
+  static_ohc_green_logo:
     type: string
 
   static_dpg_white_logo:

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -8,6 +8,8 @@
     "static_header_logo": "https://cdn.coronasafe.network/header_logo.png",
     "static_light_logo": "https://cdn.coronasafe.network/light-logo.svg",
     "static_black_logo": "https://cdn.coronasafe.network/black-logo.svg",
+    "static_ohc_light_logo": "https://cdn.coronasafe.network/ohc_logo_light.png",
+    "static_ohc_green_logo": "https://cdn.coronasafe.network/ohc_logo_green.png",
     "static_dpg_white_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
     "static_coronasafe_logo": "https://3451063158-files.gitbook.io/~/files/v0/b/gitbook-legacy-files/o/assets%2F-M233b0_JITp4nk0uAFp%2F-M2Dx6gKxOSU45cjfgNX%2F-M2DxFOkMmkPNn0I6U9P%2FCoronasafe-logo.png?alt=media&token=178cc96d-76d9-4e27-9efb-88f3186368e8",
     "gmaps_api_key": "AIzaSyDsBAc3y7deI5ZO3NtK5GuzKwtUzQNJNUk",

--- a/configs/staging.json
+++ b/configs/staging.json
@@ -11,7 +11,6 @@
     "static_ohc_light_logo": "https://cdn.coronasafe.network/ohc_logo_light.png",
     "static_ohc_green_logo": "https://cdn.coronasafe.network/ohc_logo_green.png",
     "static_dpg_white_logo": "https://digitalpublicgoods.net/wp-content/themes/dpga/images/logo-w.svg",
-    "static_coronasafe_logo": "https://3451063158-files.gitbook.io/~/files/v0/b/gitbook-legacy-files/o/assets%2F-M233b0_JITp4nk0uAFp%2F-M2Dx6gKxOSU45cjfgNX%2F-M2DxFOkMmkPNn0I6U9P%2FCoronasafe-logo.png?alt=media&token=178cc96d-76d9-4e27-9efb-88f3186368e8",
     "gmaps_api_key": "AIzaSyDsBAc3y7deI5ZO3NtK5GuzKwtUzQNJNUk",
     "gov_data_api_key": "579b464db66ec23bdd000001cdd3946e44ce4aad7209ff7b23ac571b",
     "recaptcha_site_key": "6LdvxuQUAAAAADDWVflgBqyHGfq-xmvNJaToM0pN",


### PR DESCRIPTION
This PR removes all references of coronasafe brandings, and adds support for OHC branding.